### PR TITLE
Feat/audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,35 @@
-# @contentful/field-editors
+# citizensadvice/field-editor
 
-[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
+Contentful upstream [README.md](https://github.com/contentful/field-editors/blob/master/README.md)
 
-This is the monorepo for all field editors and apps by [Contentful][contentful].
+## Changes
 
-Since these are developed using the [App SDK][app-sdk], this will allow you to understand how each editor works, fork existing apps or create your own apps based on existing Contentful components' source rather than starting from scratch.
+### References package (`packages/reference`)
 
-It uses [Typescript][typescript], [React][react], [Forma36][forma36] (a design system & component library by Contentful) and is managed using [Lerna][lerna]. Code is automatically formatted with [Prettier][prettier] and checked with [ESLint][eslint] on every commit using Git hooks.
+- contains:
+  - custom card footer that has similar code to the one in [contentful-show-audience](https://github.com/citizensadvice/contentful-show-audience) app
+- depends on:
+  - no customised deps
 
-## Available field editors
+### Rich-text package (`packages/rich-text`)
 
-Playground with all components: [https://contentful-field-editors.netlify.app/](https://contentful-field-editors.netlify.app/)
+- contains:
+  - no customisation of the code
+- depends on:
+  - the customised references package
 
-This repository has all editorial components that you can find in the Contentful Web application.
-You can run each of these component as a custom field app or compose them into a custom entry app.
-You could also use these components as the basis for a custom [Contentful App](https://www.contentful.com/app-framework/)
+---
 
-- Single line editor
-- Multi line editor
-- Dropdown
-- Tags
-- List
-- Checkbox
-- Radio
-- Boolean
-- Rating
-- Number
-- Url
-- JSON
-- Location
-- Date
-- Markdown
-- Slug
-- Entry reference / Media
-- Rich Text
+## Repositories dependant on citizensadvice/field-editor
 
-Also this repository contains shared packages that simplify development and testing of field and entry apps.
+### [Contentful Rich Text](https://github.com/citizensadvice/contentful-rich-text) (app)
 
-Feel free to reach out to us with the ones that'd be the most useful to have
-here by filing a [Github issue][github-issues]!
+- purpose:
 
-### Styles
+  - customise the rich text field of entries by displaying audiences in linked entry cards
 
-To achieve the same field editor look as in the Contentful UI, you need to render `GlobalStyled` component.
-
-```jsx
-import { GlobalStyles } '@contentful/f36-components';
-
-function Root() {
-  return (
-    <>
-      <GlobalStyles />
-      <MyApp />
-    </>
-  );
-}
-```
-
-## Getting started & contributing
-
-### Requirements
-
-- Node.js: `>=12.13.1`
-- Yarn: `>=1.21.1`
-
-To install all dependencies and build all packages run the following commands from the root of the project.
-
-```
-yarn
-yarn build
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to get started.
-
-We'd love to have your helping hand on `@contentful/field-editors`!
-
-## Links & related repositories
-
-- [App SDK][app-sdk]
-- [Create Contentful App CLI][create-contentful-app]
-- [Forma 36][forma36]
-
-## Code of Conduct
-
-We want to provide a safe, inclusive, welcoming, and harassment-free space and experience for all participants, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, religion (or lack thereof), or other identity markers.
-
-[Read our full Code of Conduct](https://github.com/contentful-developer-relations/community-code-of-conduct).
-
-## License
-
-All field editor packages are open source software [licensed as MIT](./LICENSE).
-
-[contentful]: https://www.contentful.com
-[app-sdk]: https://github.com/contentful/ui-extensions-sdk
-[create-contentful-app]: https://github.com/contentful/create-contentful-app
-[github-issues]: https://github.com/contentful/field-editors/issues
-[forma36]: https://github.com/contentful/forma-36
-[typescript]: https://www.typescriptlang.org/
-[react]: https://reactjs.org/
-[lerna]: https://github.com/lerna/lerna
-[prettier]: https://prettier.io/
-[eslint]: https://eslint.org/
+- contains:
+  - no custom app code
+  - field app set in appearance
+- depends-on:
+  - citizensadvice/field-editor

--- a/packages/reference/src/components/CardFooter/CardFooter.tsx
+++ b/packages/reference/src/components/CardFooter/CardFooter.tsx
@@ -1,0 +1,44 @@
+import tokens from '@contentful/f36-tokens';
+import { Badge, Flex, Text } from '@contentful/f36-components';
+import { nanoid } from 'nanoid';
+import React from 'react';
+
+interface CardFooterProps {
+  audiences: Array<string>;
+}
+
+export function CardFooter(props: CardFooterProps) {
+  const { audiences } = props;
+
+  const styles = {
+    audienceContainer: {
+      borderTopColor: tokens.gray200,
+      borderTopWidth: 1,
+      borderTopStyle: 'solid',
+      paddingTop: tokens.spacingXs,
+      width: `calc(100% + ${tokens.spacingM} * 2)`,
+      marginLeft: `-${tokens.spacingM}`,
+      paddingLeft: tokens.spacingM,
+      paddingRight: tokens.spacingM,
+      marginBottom: `-${tokens.spacingS}`,
+    } as React.CSSProperties,
+    badge: {
+      textTransform: 'none',
+      marginLeft: tokens.spacingS,
+      letterSpacing: 0,
+    } as React.CSSProperties,
+  };
+
+  return audiences && audiences.length ? (
+    <Flex style={styles.audienceContainer}>
+      <Flex flexGrow={1}>
+        <Text fontColor="gray600">Country audience</Text>
+      </Flex>
+      {audiences.map((audience: string) => (
+        <Badge key={nanoid()} style={styles.badge}>
+          {audience}
+        </Badge>
+      ))}
+    </Flex>
+  ) : null;
+}

--- a/packages/reference/src/components/index.ts
+++ b/packages/reference/src/components/index.ts
@@ -7,3 +7,4 @@ export { CreateEntryMenuTrigger } from './CreateEntryLinkButton/CreateEntryMenuT
 export { ScheduledIconWithTooltip } from './ScheduledIconWithTooltip/ScheduledIconWithTooltip';
 export { getScheduleTooltipContent } from './ScheduledIconWithTooltip/ScheduleTooltip';
 export { AssetThumbnail } from './AssetThumbnail/AssetThumbnail';
+export { CardFooter } from './CardFooter/CardFooter';

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -103,7 +103,6 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
 
   const audiences = props.entry.fields?.audience?.[props.localeCode];
 
-  console.log(audiences, 'audiences from field-editor');
   return (
     <EntryCard
       as={props.entryUrl ? 'a' : 'article'}
@@ -176,7 +175,6 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
         if (!props.isClickable) return;
         props.onEdit && props.onEdit();
       }}>
-      Audiences to appear here
       <CardFooter audiences={audiences} />
     </EntryCard>
   );

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -5,7 +5,12 @@ import { SpaceAPI } from '@contentful/app-sdk';
 import { EntryCard, MenuItem, MenuDivider } from '@contentful/f36-components';
 import { ContentType, Entry, File, RenderDragFn } from '../../types';
 import { entityHelpers, isValidImage } from '@contentful/field-editor-shared';
-import { AssetThumbnail, MissingEntityCard, ScheduledIconWithTooltip } from '../../components';
+import {
+  AssetThumbnail,
+  MissingEntityCard,
+  ScheduledIconWithTooltip,
+  CardFooter,
+} from '../../components';
 
 import { ClockIcon } from '@contentful/f36-icons';
 
@@ -96,6 +101,8 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
     defaultLocaleCode: props.defaultLocaleCode,
   });
 
+  const audiences = props.entry.fields?.audience?.[props.localeCode];
+
   return (
     <EntryCard
       as={props.entryUrl ? 'a' : 'article'}
@@ -167,8 +174,9 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
         e.preventDefault();
         if (!props.isClickable) return;
         props.onEdit && props.onEdit();
-      }}
-    />
+      }}>
+      <CardFooter audiences={audiences} />
+    </EntryCard>
   );
 }
 

--- a/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
+++ b/packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx
@@ -103,6 +103,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
 
   const audiences = props.entry.fields?.audience?.[props.localeCode];
 
+  console.log(audiences, 'audiences from field-editor');
   return (
     <EntryCard
       as={props.entryUrl ? 'a' : 'article'}
@@ -175,6 +176,7 @@ export function WrappedEntryCard(props: WrappedEntryCardProps) {
         if (!props.isClickable) return;
         props.onEdit && props.onEdit();
       }}>
+      Audiences to appear here
       <CardFooter audiences={audiences} />
     </EntryCard>
   );

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -27,7 +27,7 @@
     "@contentful/f36-components": "^4.0.27",
     "@contentful/f36-icons": "^4.1.0",
     "@contentful/f36-tokens": "^4.0.0",
-    "@contentful/field-editor-reference": "^4.1.2",
+    "@contentful/field-editor-reference": "github:citizensadvice/field-editors#contentful-field-editor-reference-v4.1.2-gitpkg",
     "@contentful/field-editor-shared": "^1.1.2",
     "@contentful/rich-text-plain-text-renderer": "^14.0.0",
     "@contentful/rich-text-types": "^14.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,7 +1663,7 @@
     read-pkg-up "^7.0.1"
     semver "^7.3.2"
 
-"@contentful/f36-accordion@^4.0.1", "@contentful/f36-accordion@^4.1.4":
+"@contentful/f36-accordion@^4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@contentful/f36-accordion/-/f36-accordion-4.1.4.tgz#d7d46a7114274f2df47993920bb4c203d6eb35a3"
   integrity sha512-rcbNffTyPneGyQ9E5fmp1Ebw5GGHNtjYps9BwLjgcnIu3uy3v6tH7qmeJdRbGEJezK0zhpDJOeNjx7kkS6Ke+A==
@@ -1676,7 +1676,7 @@
     "@contentful/f36-typography" "^4.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-asset@^4.0.1", "@contentful/f36-asset@^4.1.3":
+"@contentful/f36-asset@^4.1.3":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@contentful/f36-asset/-/f36-asset-4.1.3.tgz#7db849e756a6e2a1cdccc6613034381927a1c1bf"
   integrity sha512-wgpETTejOrqgEd8SbuO8ug5iL3df52niJ2zH+uRIbS9a2Z+tc8OCeCczaUeGrvEFvSC13/akIyhqqxHA6ENGuQ==
@@ -1689,7 +1689,7 @@
     "@contentful/f36-typography" "^4.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-autocomplete@^4.0.1", "@contentful/f36-autocomplete@^4.2.1":
+"@contentful/f36-autocomplete@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-autocomplete/-/f36-autocomplete-4.2.1.tgz#c8e21bb72125f01419aa58da05cebc35dcd5605b"
   integrity sha512-IFKGVMthpZhMh2EGVOz1srhT1r4FhHrH14IWVZN3hIse/fblg+XQQLyQYJt1O/jzt8sVls67bcMUIs0sBX5dng==
@@ -1707,7 +1707,7 @@
     downshift "^6.1.7"
     emotion "^10.0.17"
 
-"@contentful/f36-badge@^4.0.1", "@contentful/f36-badge@^4.1.1":
+"@contentful/f36-badge@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-badge/-/f36-badge-4.1.1.tgz#48cdd81e04bc03432345c0b9ff153384818cb77b"
   integrity sha512-GhqSNuSa3HIVxL/VFHUgn5HeGUPcyKZBO1kDiRBWnytn3vfLQHbH3peU3DprNPTjlSqNyAtsl025I4Sf+poujw==
@@ -1717,7 +1717,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-button@^4.0.1", "@contentful/f36-button@^4.2.1":
+"@contentful/f36-button@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-button/-/f36-button-4.2.1.tgz#259ed1a0236f651ed8f91817b3d913d77b06bbc1"
   integrity sha512-QjYzQQ+0to4kOr9zokp9v/LgMreUC6TqWB48n5V01BTJ9FZvh1erGT5pIBpxAlaDQowk26qchXPwl9O8I0yA/w==
@@ -1728,7 +1728,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-card@^4.0.1", "@contentful/f36-card@^4.1.15":
+"@contentful/f36-card@^4.1.15":
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/@contentful/f36-card/-/f36-card-4.1.15.tgz#da8fe1206f2d59ad83d0e4ebbe1053d8d1a7a898"
   integrity sha512-qJ+bXxmWHMr7TIxpDIJIsbKRlbd1ChghXmWUbGbonUY6Birhnuvt59LYcyc8kSjuKAPZGU/ntUuK5rX6SHCBPA==
@@ -1749,7 +1749,7 @@
     emotion "^10.0.17"
     truncate "^2.0.1"
 
-"@contentful/f36-collapse@^4.1.0", "@contentful/f36-collapse@^4.2.2":
+"@contentful/f36-collapse@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@contentful/f36-collapse/-/f36-collapse-4.2.2.tgz#4871851f999eca45ab31e4479613b85f8474d1f4"
   integrity sha512-QRpNnHVzvJ2dfPD56qimhltz+LqoUrQI5WbC+tpXsqzSX+n04fB6nJzqwPdB3i1dCNeGbSpcEI0INNM//+yoRQ==
@@ -1799,7 +1799,7 @@
     "@types/react" "16.14.22"
     "@types/react-dom" "16.9.14"
 
-"@contentful/f36-copybutton@^4.0.1", "@contentful/f36-copybutton@^4.1.3":
+"@contentful/f36-copybutton@^4.1.3":
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/@contentful/f36-copybutton/-/f36-copybutton-4.1.3.tgz#8b261ee6ec90c8b9603f93bb7252927d47ad771b"
   integrity sha512-9EhLiDmIYlruWC0Qxw3pgUosTJh2IMBTlE6YOQlZpfYM7B+h/aXsMY5EVcFr2VbekWlXNfPlC/BWyort+NRKHg==
@@ -1812,7 +1812,7 @@
     emotion "^10.0.17"
     react-copy-to-clipboard "^5.0.3"
 
-"@contentful/f36-core@^4.0.1", "@contentful/f36-core@^4.1.1":
+"@contentful/f36-core@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-core/-/f36-core-4.1.1.tgz#e11437b9a2610cd20871fb0626e43c4e251dcea3"
   integrity sha512-IIPp1Nw+9t6KIMCiWl7MTMHg/6Gm3OopyZcBYSip1r1iZuhwf0xSLxwJUOoByWvjtEbyzuud0qwwFEbjnrOEyw==
@@ -1824,7 +1824,7 @@
     emotion "^10.0.17"
     emotion-normalize "^10.1.0"
 
-"@contentful/f36-datetime@^4.1.0", "@contentful/f36-datetime@^4.2.1":
+"@contentful/f36-datetime@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-datetime/-/f36-datetime-4.2.1.tgz#24085b85976dc463205d08e7ae0b8f9997197f9f"
   integrity sha512-N8seBas2GI+cpOJjPRVtP1753nnRg0k65BgdlC9M6igg6g/CalXUlmsE/g8mawV/LTogmsrXd3aC3j50gapCCQ==
@@ -1835,7 +1835,7 @@
     dayjs "^1.10.6"
     emotion "^10.0.17"
 
-"@contentful/f36-drag-handle@^4.0.1", "@contentful/f36-drag-handle@^4.1.4":
+"@contentful/f36-drag-handle@^4.1.4":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@contentful/f36-drag-handle/-/f36-drag-handle-4.1.4.tgz#102c131727fae68a8eb9f1ead34e0bf79bddde16"
   integrity sha512-siRgWn2aWaXnUC0TLQtm2v1C2Zv4nCx7Y6VuLIkoEhNHtUD4M5/cLHTzICWiRGpMhbAr4BzBZYPk6STZc+M/iw==
@@ -1846,7 +1846,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-entity-list@^4.0.1", "@contentful/f36-entity-list@^4.1.13":
+"@contentful/f36-entity-list@^4.1.13":
   version "4.1.13"
   resolved "https://registry.yarnpkg.com/@contentful/f36-entity-list/-/f36-entity-list-4.1.13.tgz#4295f78df074cfb4d20e6d4ff3418a4ece1ad507"
   integrity sha512-E3h9ieLSVxj9Xv+AdPbH3Hq1bidt/5JN0O768UWk0L/+p3Be+pPGmULaYbdgM8twSE/S2QvUXp0YLW/lEs60Rw==
@@ -1864,7 +1864,7 @@
     "@contentful/f36-typography" "^4.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-forms@^4.0.1", "@contentful/f36-forms@^4.2.1":
+"@contentful/f36-forms@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-forms/-/f36-forms-4.2.1.tgz#18fa9b0a794d662d1783799c150dd8df8bf274c7"
   integrity sha512-a1rG8J6LS2N+j6Y5VuwrHQhe/qLfbRAnXm3R+wFo0yRhv9rilUM3JyzR8XoiBFpZzf60YZzSd13hxlktVJ3MWQ==
@@ -1876,7 +1876,7 @@
     "@contentful/f36-typography" "^4.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-icon@^4.0.1", "@contentful/f36-icon@^4.1.1":
+"@contentful/f36-icon@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-icon/-/f36-icon-4.1.1.tgz#9a9569b451d142f582c51454eed05f72a4642293"
   integrity sha512-LOn96LwynmoyVdC2M7QIS4e15zwekvlEtcVc1L5TOu/W49/FazoR/G6b8opFrrQiWnqL+A51w8LfflYO0hL9LA==
@@ -1886,7 +1886,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-icons@^4.0.1", "@contentful/f36-icons@^4.1.0":
+"@contentful/f36-icons@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@contentful/f36-icons/-/f36-icons-4.1.0.tgz#503d2b1d4cf5f47b11680cfa20239e4efd08d651"
   integrity sha512-SVbq9as3FPFQQUrJ+id2NmePZDDoTmSm9E5AI7AbO5JGpCQoGzDBHxD3I04naJmbE91puNSVXQxV/zqC/aVqTA==
@@ -1897,7 +1897,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-list@^4.0.1", "@contentful/f36-list@^4.1.1":
+"@contentful/f36-list@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-list/-/f36-list-4.1.1.tgz#f82135e098d84113d529f5d904bb1ef6d375b0ec"
   integrity sha512-r6Oiy2fuBqowrUdbm1o5twHxa800sGsyzxBCYUHZ00tYKQTJgr5V78T9pwYUqIYNviUq8BEO06dE9tDaWzygEw==
@@ -1907,7 +1907,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-menu@^4.0.1", "@contentful/f36-menu@^4.2.2":
+"@contentful/f36-menu@^4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@contentful/f36-menu/-/f36-menu-4.2.2.tgz#96bfb90ab62ffb358e7945a0376607ca323c6aee"
   integrity sha512-A5pwkWFiS80A54XNxNfEr2uMqhlyz/tNBlpdJSDhfwv+wA/h60km5FfhK4AfbF6U7FyG5uM9cJ1nkFMLVolBeg==
@@ -1921,7 +1921,7 @@
     "@contentful/f36-utils" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-modal@^4.0.1", "@contentful/f36-modal@^4.2.1":
+"@contentful/f36-modal@^4.2.1":
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-modal/-/f36-modal-4.2.1.tgz#97f282528220f2adae39a2e6497ab25948b9ce42"
   integrity sha512-Kj5XZ3vMWSX0rDWyPgmnPEPIZ44D0OXI93nnyjCjC5IYuwDf5YqBbckbt03ltsC/lywZXj9Bz9eTICV58Sv6UQ==
@@ -1936,7 +1936,7 @@
     emotion "^10.0.17"
     react-modal "^3.14.3"
 
-"@contentful/f36-note@^4.0.1", "@contentful/f36-note@^4.2.8":
+"@contentful/f36-note@^4.2.8":
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/@contentful/f36-note/-/f36-note-4.2.8.tgz#89416c2ab4bf29e20db5fc64c9a7b1a72254b019"
   integrity sha512-yZgEY2uXRR0FeMpG6wxsO2rQnU1eThE3L2e6/NRzPLEJWE+iNLOCmmiT+NZdIjoj57qP6l8dJFtAS6OYHRl/bQ==
@@ -1950,7 +1950,7 @@
     "@contentful/f36-typography" "^4.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-notification@^4.0.1", "@contentful/f36-notification@^4.0.11":
+"@contentful/f36-notification@^4.0.11":
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/@contentful/f36-notification/-/f36-notification-4.0.11.tgz#d3db4175cedcc86c599699d9ca82596a95e9d672"
   integrity sha512-TAm42X3s3CnuyNWiObDqeYUwgJig8XFhacNvsbbCDeBsGVgIxtaqlAJZiRga1okGCPrM3mhV+fDE2oVFeZg8iQ==
@@ -1965,7 +1965,7 @@
     emotion "^10.0.17"
     react-animate-height "^2.0.23"
 
-"@contentful/f36-pill@^4.0.1", "@contentful/f36-pill@^4.1.9":
+"@contentful/f36-pill@^4.1.9":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@contentful/f36-pill/-/f36-pill-4.1.9.tgz#92b45731ccbb419bedc221679035a3d55b7d140b"
   integrity sha512-fLlkijQEDfoFlQkNbjzuoLhUrGmxtBcbZEptkVGiHwGJlvK8gOR81dsyW4qOUJHCqFpMOWOI5dbIjDayyWlzng==
@@ -1977,7 +1977,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-popover@^4.0.1", "@contentful/f36-popover@^4.2.0":
+"@contentful/f36-popover@^4.2.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@contentful/f36-popover/-/f36-popover-4.2.0.tgz#d39f58648c759eb02e13f1deed17a19db371f0d0"
   integrity sha512-StVLiGWx+JaoAWPzqqxbztIdsrsDM3P2Gho3jxrjD/RCi2GYvyC9pozWvAv7iyzA1BxguBlzQ/2a/6ybWKd4/w==
@@ -1990,7 +1990,7 @@
     emotion "^10.0.17"
     react-popper "^2.2.3"
 
-"@contentful/f36-skeleton@^4.0.1", "@contentful/f36-skeleton@^4.1.1":
+"@contentful/f36-skeleton@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-skeleton/-/f36-skeleton-4.1.1.tgz#6685adb0dc7ceb9cfb2794d9f25c3c5dd7163324"
   integrity sha512-4BUJXxqVxf3K2XkWEd8PjGtfA/yMaSlMX70eBVhjNoQzaf0tsKCMIlDMtLHLsnluPPavJpncET64pZrY5tWkFA==
@@ -2001,7 +2001,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-spinner@^4.0.1", "@contentful/f36-spinner@^4.1.1":
+"@contentful/f36-spinner@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-spinner/-/f36-spinner-4.1.1.tgz#fd6aef40af2665f9348469ee6d7e9fc1cf4a3f87"
   integrity sha512-0Fxv6KG1499Pbtt61xOxIa/PXx+3XWeYgJc6vAx6Y4HSiQ90I9ZOqWM7u5n8AcXQ4014+VgRB41sAblrTplWOg==
@@ -2011,7 +2011,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-table@^4.0.1", "@contentful/f36-table@^4.1.1":
+"@contentful/f36-table@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-table/-/f36-table-4.1.1.tgz#0c44752375a51edcb45fe4bc90c5b1437d65dab4"
   integrity sha512-sLpub05XU0ALQlY527QBMMEnjn9S0SuG2xoYZGdBWyw0lNSRPlgZT8c7TvBE2NGKBSBA4cNb/MljYEUkfw0i2w==
@@ -2021,7 +2021,7 @@
     "@contentful/f36-tokens" "^4.0.0"
     emotion "^10.0.17"
 
-"@contentful/f36-tabs@^4.0.1", "@contentful/f36-tabs@^4.1.2":
+"@contentful/f36-tabs@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@contentful/f36-tabs/-/f36-tabs-4.1.2.tgz#a33075af476a06e525738b716df3c3bd93053c79"
   integrity sha512-nHdVmr3qBFESDpDWH2yiyfwpIc/r8c/cEdqnnvj2L3s75JXO/JzQUlq4ym5Ji5I3kIb7rtyBxTyhNrZOrmhC1A==
@@ -2032,7 +2032,7 @@
     "@radix-ui/react-tabs" "0.1.1"
     emotion "^10.0.17"
 
-"@contentful/f36-text-link@^4.0.1", "@contentful/f36-text-link@^4.1.1":
+"@contentful/f36-text-link@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-text-link/-/f36-text-link-4.1.1.tgz#e0d5fa30e8496195364f8f7e524a21df82d12572"
   integrity sha512-jjZ+4zNCjcZG6k5urZC91PJV1jvzkW4sHEj6B6MOwj5sg3phRBmUhVCMBDEnzG1gr0lAyID7ONxdtkYxYzAVnQ==
@@ -2047,7 +2047,7 @@
   resolved "https://registry.yarnpkg.com/@contentful/f36-tokens/-/f36-tokens-4.0.0.tgz#f7fd222f820ace9e343c7b9b20591c4e99e5e596"
   integrity sha512-gfHJ34ZxlFwqlyUX7RaaEn5f076+zW9tQOAAmWaxkDTGFtpqAyjZnByCFXz3nrB0VyZtOxhRgttaQo/u7zFt0w==
 
-"@contentful/f36-tooltip@^4.0.1", "@contentful/f36-tooltip@^4.1.1":
+"@contentful/f36-tooltip@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-tooltip/-/f36-tooltip-4.1.1.tgz#d4869625d19f7c43c22fe7289e3388d2598d37cf"
   integrity sha512-EBjFW9Y3rOTd+VF9Rz8J5PoS/wl19KCnrnnDcR4W01ApcSxocHCfO8nrLrLQtLvqpJhuIPQUbFD+ANkxlj6MQg==
@@ -2061,7 +2061,7 @@
     emotion "^10.0.17"
     react-popper "^2.2.3"
 
-"@contentful/f36-typography@^4.0.1", "@contentful/f36-typography@^4.1.1":
+"@contentful/f36-typography@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/f36-typography/-/f36-typography-4.1.1.tgz#41f06bbed7d83f103d41992cafa85723aa6748c6"
   integrity sha512-AOBK2sK+pZxz6+mq4WI+8MuT6Aa7vgdOCYhFIO3YK15tb115ahLT7r8/B+SvI3IsyKv2+JXkqDJitUucMeLwyw==
@@ -2264,17 +2264,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@cypress/listr-verbose-renderer@^0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#a77492f4b11dcc7c446a34b3e28721afd33c642a"
-  integrity sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
-"@cypress/request@^2.88.5", "@cypress/request@^2.88.7":
+"@cypress/request@^2.88.7":
   version "2.88.9"
   resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.9.tgz#7428fc66008ec3a4727c189857f6bb7f758f1d92"
   integrity sha512-6md3dtAd3DXfTEXFb2Yde3TSaqpYsSBw3a1VFwAC9Fscu2B0DtY2Venu35csZyJj09XNkPMGRoE4ZXUdtkI+zg==
@@ -4683,13 +4673,6 @@
     "@types/codemirror" "*"
     "@types/react" "*"
 
-"@types/react-dom@16.9.10":
-  version "16.9.10"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.10.tgz#4485b0bec3d41f856181b717f45fd7831101156f"
-  integrity sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==
-  dependencies:
-    "@types/react" "^16"
-
 "@types/react-dom@16.9.12":
   version "16.9.12"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.12.tgz#55cd6b17e73922edb9545e5355a0016c1734e6f4"
@@ -4725,7 +4708,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.14.2", "@types/react@16.14.22", "@types/react@16.14.5", "@types/react@>=16.9.0", "@types/react@^16", "@types/react@^17.0.11":
+"@types/react@*", "@types/react@16.14.22", "@types/react@16.14.5", "@types/react@>=16.9.0", "@types/react@^16", "@types/react@^17.0.11":
   version "16.14.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.5.tgz#2c39b5cadefaf4829818f9219e5e093325979f4d"
   integrity sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==
@@ -4753,7 +4736,7 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
-"@types/sinonjs__fake-timers@^6.0.1", "@types/sinonjs__fake-timers@^6.0.2":
+"@types/sinonjs__fake-timers@^6.0.2":
   version "6.0.4"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.4.tgz#0ecc1b9259b76598ef01942f547904ce61a6a77d"
   integrity sha512-IFQTJARgMUBF+xVd2b+hIgXWrZEjND3vJtRCvIelcFB5SIXfjV4bOHbHJ0eXKh+0COrBRc8MqteKAz/j88rE0A==
@@ -5560,7 +5543,7 @@ aproba@^2.0.0:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
-arch@^2.1.0, arch@^2.1.2, arch@^2.2.0:
+arch@^2.1.0, arch@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.2.0.tgz#1bc47818f305764f23ab3306b0bfc086c5a29d11"
   integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
@@ -6386,7 +6369,7 @@ blessed@^0.1.81:
   resolved "https://registry.yarnpkg.com/blessed/-/blessed-0.1.81.tgz#f962d687ec2c369570ae71af843256e6d0ca1129"
   integrity sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk=
 
-blob-util@2.0.2, blob-util@^2.0.2:
+blob-util@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
   integrity sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==
@@ -7633,7 +7616,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@^1.6.2, concat-stream@~1.6.0:
+concat-stream@^1.4.7, concat-stream@^1.5.0, concat-stream@~1.6.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -7847,7 +7830,7 @@ contentful-resolve-response@^1.3.0:
   dependencies:
     fast-copy "^2.1.0"
 
-contentful-sdk-core@^6.10.1, contentful-sdk-core@^6.5.0, contentful-sdk-core@^6.8.0:
+contentful-sdk-core@^6.10.1, contentful-sdk-core@^6.5.0:
   version "6.10.1"
   resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-6.10.1.tgz#32197c6084190108dbb89569f16c0e2e33da38db"
   integrity sha512-q1dh5AHL3FoBc3CZThQMtnaxgFbs9BrJW8wDysdp/IT/Q2edgUQASh2fvj02T6cCh3ftMspRRe/HMfZDF9FfIQ==
@@ -10257,7 +10240,7 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
-eventemitter2@^6.4.2, eventemitter2@^6.4.3:
+eventemitter2@^6.4.3:
   version "6.4.5"
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.5.tgz#97380f758ae24ac15df8353e0cc27f8b95644655"
   integrity sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==
@@ -10318,7 +10301,7 @@ execa@3.4.0, execa@^3.2.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-execa@4.1.0, execa@^4.0.0, execa@^4.0.2, execa@^4.0.3, execa@^4.1.0:
+execa@4.1.0, execa@^4.0.0, execa@^4.0.3, execa@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
   integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
@@ -10560,16 +10543,6 @@ extract-zip@2.0.1:
     yauzl "^2.10.0"
   optionalDependencies:
     "@types/yauzl" "^2.9.1"
-
-extract-zip@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-1.7.0.tgz#556cc3ae9df7f452c493a0cfb51cc30277940927"
-  integrity sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
-  dependencies:
-    concat-stream "^1.6.2"
-    debug "^2.6.9"
-    mkdirp "^0.5.4"
-    yauzl "^2.10.0"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -11431,13 +11404,6 @@ global-dirs@^0.1.1:
   integrity sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=
   dependencies:
     ini "^1.3.4"
-
-global-dirs@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-2.0.1.tgz#acdf3bb6685bcd55cb35e8a052266569e9469201"
-  integrity sha512-5HqUqdhkEovj2Of/ms3IeS/EekcO54ytHRLV4PEY2rhRwrHXLQjeVEES0Lhka0xwNDtGYn58wyC4s5+MHsOO6A==
-  dependencies:
-    ini "^1.3.5"
 
 global-dirs@^3.0.0:
   version "3.0.0"
@@ -12869,14 +12835,6 @@ is-in-browser@^1.1.3:
   resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
   integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
-is-installed-globally@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.3.2.tgz#fd3efa79ee670d1187233182d5b0a1dd00313141"
-  integrity sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
-  dependencies:
-    global-dirs "^2.0.1"
-    is-path-inside "^3.0.1"
-
 is-installed-globally@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
@@ -12980,7 +12938,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-path-inside@^3.0.1, is-path-inside@^3.0.2:
+is-path-inside@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -15697,7 +15655,7 @@ mkdirp@*, mkdirp@1.x, mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
+mkdirp@0.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.5, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -15784,7 +15742,7 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-moment@>=2.14.0, moment@^2.18.1, moment@^2.20.0, moment@^2.22.2, moment@^2.27.0:
+moment@>=2.14.0, moment@^2.18.1, moment@^2.20.0, moment@^2.22.2:
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.27.0.tgz#8bff4e3e26a236220dfe3e36de756b6ebaa0105d"
   integrity sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==
@@ -18430,11 +18388,6 @@ ramda@^0.27.1:
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
   integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
-
-ramda@~0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
 
 randexp@0.4.6:
   version "0.4.6"
@@ -22152,11 +22105,6 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,6 +2116,25 @@
     moment "^2.20.0"
     react-sortable-hoc "^2.0.0"
 
+"@contentful/field-editor-reference@github:citizensadvice/field-editors#contentful-field-editor-reference-v4.1.2-gitpkg":
+  version "4.1.2"
+  resolved "https://codeload.github.com/citizensadvice/field-editors/tar.gz/7ceb33fcf4f18882234a623950d0070371c7289e"
+  dependencies:
+    "@contentful/f36-components" "^4.0.27"
+    "@contentful/f36-icons" "^4.1.0"
+    "@contentful/f36-tokens" "^4.0.0"
+    "@contentful/field-editor-shared" "^1.1.2"
+    "@contentful/mimetype" "^1.4.0"
+    "@types/deep-equal" "^1.0.1"
+    array-move "^3.0.0"
+    constate "3.2.0"
+    deep-equal "2.0.5"
+    emotion "^10.0.17"
+    lodash "^4.17.15"
+    lodash-es "^4.17.15"
+    moment "^2.20.0"
+    react-sortable-hoc "^2.0.0"
+
 "@contentful/field-editor-rich-text@^0.19.19":
   version "0.19.20"
   resolved "https://registry.yarnpkg.com/@contentful/field-editor-rich-text/-/field-editor-rich-text-0.19.20.tgz#35fc873fb1e1d2ee26cb20ddb7b9313727331da5"


### PR DESCRIPTION
[Original task](https://citizensadvice.atlassian.net/wiki/spaces/NP/pages/3411247189/Show+Audience+when+embedding+linking+to+an+entry) (see `‘CA Rich content’ app` bullet point)

---

Modifying field-editors to display audience in the rich-text app. Using similar approach as in the [contentful-show-audience](https://github.com/citizensadvice/contentful-show-audience/pull/1) app:

- [packages/reference/src/components/CardFooter/CardFooter.tsx](https://github.com/citizensadvice/field-editors/pull/1/files#diff-09b14c7f3970fb905510c7ce7829d97b92f56318b3fdbd22d714565841bd31ae) - displaying audience in the footer
- [packages/reference/src/entries/WrappedEntryCard/WrappedEntryCard.tsx](https://github.com/citizensadvice/field-editors/pull/1/files#diff-e44520b3716ed4d68601d44e2fadb4bbe8de645998022686d9b0c1df3d524adf) - importing the CardFooter
- [packages/rich-text/package.json](https://github.com/citizensadvice/field-editors/pull/1/files#diff-040cd50dfb1a4e19a9d0088aaa0028b4afdcd53c6c5bf906805fa059caa009f2) - this is where the gitpkg of `/reference` will be linked (currently not working)

## How to test:
In order to properly run gitpkg, the updates need to be on the master branch so that the tag is set correctly.

There is a branch of the [contentful-rich-text](https://github.com/citizensadvice/contentful-rich-text/tree/test/gitpkg) app that uses the same approach but my repo ([marianayovcheva/field-editors](https://github.com/marianayovcheva/field-editors)). If you run it it should display the audience on the reference cards in the rich text editors: 
<img width="784" alt="Screenshot 2022-03-09 at 14 18 46" src="https://user-images.githubusercontent.com/94383569/157461420-82ec86b2-98bc-439d-b131-9c403b3f2a4f.png">

## TODO after initial merge
- Add tests
- Generate Gitpkg for `/rich-text` and `/reference`
- Link the correct packages in the `contentful-rich-text` app
- Make a PR for `contentful-rich-text`
- Update the README.md