### PR TITLE
Adding unit test for card footer

### DIFF
--- a/packages/reference/src/components/CardFooter/CardFooter.spec.tsx
+++ b/packages/reference/src/components/CardFooter/CardFooter.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { CardFooter } from './CardFooter';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+const audiences = ['England', 'Wales'];
+
+describe('Card footer', () => {
+  it('renders the card footer title', () => {
+    const { getByText } = render(<CardFooter audiences={audiences} />);
+
+    expect(getByText('Country audience')).toBeVisible();
+  });
+
+  it('renders audience badges', () => {
+    const { getByText } = render(<CardFooter audiences={audiences} />);
+
+    expect(getByText('England')).toBeVisible();
+    expect(getByText('Wales')).toBeVisible();
+  });
+
+  it('does not render the component when there is no audience', () => {
+    const { container } = render(<CardFooter audiences={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
Adding unit test for CardFooter. Same as in contentful-show-audience app